### PR TITLE
Reduce job size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The predictions are located at `/eos/user/j/jowulff/res_HH/Condor_out/prediction
 
 ###  1. Create submission dirs and .dag files.
 
+You need to use at least python version 3.6.
+
 ```
 cd hbt_klub_inference/add_branch
 python3 write_dag_addBranch.py -s ~/afs/submit_dir \

--- a/add_branch/write_dag_addBranch.py
+++ b/add_branch/write_dag_addBranch.py
@@ -38,7 +38,7 @@ log                     = $(ClusterId).log\n\
 error                   = $(ClusterId).$(ProcId).err\n\
 output                  = $(ClusterId).$(ProcId).out\n\
 \n\
-MY.JobFlavour = \"espresso\"\n\
+MY.JobFlavour = \"microcentury\"\n\
 MY.WantOS = \"el7\"\n\
 \n\
 Arguments = $(FILES)\n\
@@ -101,7 +101,7 @@ files for sample ({i+1}/{len(samples)})\r", end="")
         #if not broken_files == "":
             #broken_list = 
         files = glob(f"{sample_dir}/*.root")
-        filechunks = [files[i:i+100] for i in range(0, len(files), 100)]
+        filechunks = [files[i:i+10] for i in range(0, len(files), 10)]
         if not os.path.exists(dagfile):
             with open(dagfile, "x") as dfile:
                 for chunk in filechunks:

--- a/convert_names.sh
+++ b/convert_names.sh
@@ -13,27 +13,28 @@ function print_usage_submit_skims {
     USAGE="
         Run example: bash $(basename "$0") -d 
 
-        -h / --help[ ${HELP_STR} ]
-        -d [ ${BASEPATH_STR} ]
-        -n / --dry-run[ ${DRYRUN_STR} ]
+        -h / --help    [${HELP_STR}]
+        -d             [${BASEPATH_STR}]
+        -n / --dry-run [${DRYRUN_STR}]
 "
+    printf "${USAGE}"
 }
 
 while [[ $# -gt 0 ]]; do
     key=${1}
     case $key in
-	-h|--help)
-	    print_usage_submit_skims
-	    exit 1
-	    ;;
-	-n|--dry-run)
-	    DRYRUN="1"
-	    shift;
-	    ;;
-	-d)
-	    BASEPATH=${2}
-	    shift; shift;
-	    ;;
+		-h|--help)
+			print_usage_submit_skims
+			exit 1
+			;;
+		-n|--dry-run)
+			DRYRUN="1"
+			shift;
+			;;
+		-d)
+			BASEPATH=${2}
+			shift; shift;
+			;;
     esac
 done
 
@@ -216,7 +217,7 @@ for key in ${!TABLE[@]}; do
     value=${TABLE[${key}]}
 
     if [ -d ${BASEPATH}/${value} ]; then
-	comm="mv ${BASEPATH}/${value} ${BASEPATH}/${key}"
-	[[ ${DRYRUN} -eq 1 ]] && echo ${comm} || ${comm}
+		comm="mv ${BASEPATH}/${value} ${BASEPATH}/${key}"
+		[[ ${DRYRUN} -eq 1 ]] && echo ${comm} || ${comm}
     fi
 done


### PR DESCRIPTION
- reduce number of files processed by each job
- fix bug in printing help message of ```convert_names.sh```
- mention required minimum python version (f-strings are not supported in python < 3.6)